### PR TITLE
feat(api): Bootstrap API for OLT-BNG device registration

### DIFF
--- a/internal/api/bootstrap.go
+++ b/internal/api/bootstrap.go
@@ -1,0 +1,450 @@
+package api
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/codelaboratoryltd/nexus/internal/hashring"
+	"github.com/codelaboratoryltd/nexus/internal/store"
+	"github.com/codelaboratoryltd/nexus/internal/validation"
+)
+
+// BootstrapRequest represents a device bootstrap registration request.
+type BootstrapRequest struct {
+	// Serial is the hardware serial number (required).
+	Serial string `json:"serial"`
+
+	// MAC is the primary MAC address (required).
+	MAC string `json:"mac"`
+
+	// Model is the device model identifier (optional).
+	Model string `json:"model,omitempty"`
+
+	// Firmware is the current firmware version (optional).
+	Firmware string `json:"firmware,omitempty"`
+
+	// PublicKey is the device's public key for mTLS (optional, for future use).
+	PublicKey string `json:"public_key,omitempty"`
+}
+
+// PartnerInfo contains information about an HA partner device.
+type PartnerInfo struct {
+	// NodeID is the partner's node identifier.
+	NodeID string `json:"node_id"`
+
+	// Address is the partner's management address.
+	Address string `json:"address,omitempty"`
+
+	// Status indicates if the partner is online.
+	Status string `json:"status,omitempty"`
+}
+
+// PoolAssignment represents a pool assigned to a device.
+type PoolAssignment struct {
+	// PoolID is the pool identifier.
+	PoolID string `json:"pool_id"`
+
+	// CIDR is the pool's IP range.
+	CIDR string `json:"cidr"`
+
+	// Subnets are the specific subnets assigned to this node.
+	Subnets []string `json:"subnets,omitempty"`
+}
+
+// ClusterInfo contains information about the Nexus cluster.
+type ClusterInfo struct {
+	// Peers is the list of Nexus peer addresses.
+	Peers []string `json:"peers,omitempty"`
+
+	// SyncEndpoint is the endpoint for state synchronization.
+	SyncEndpoint string `json:"sync_endpoint,omitempty"`
+}
+
+// BootstrapResponse is returned to devices after successful bootstrap.
+type BootstrapResponse struct {
+	// NodeID is the unique identifier assigned to this device.
+	NodeID string `json:"node_id"`
+
+	// Status is the device's current status ("configured" or "pending").
+	Status string `json:"status"`
+
+	// SiteID is the assigned site identifier (if configured).
+	SiteID string `json:"site_id,omitempty"`
+
+	// Role is the device role in an HA pair ("active" or "standby").
+	Role string `json:"role,omitempty"`
+
+	// Partner contains HA partner information (if configured).
+	Partner *PartnerInfo `json:"partner,omitempty"`
+
+	// Pools is the list of assigned IP pools (if configured).
+	Pools []PoolAssignment `json:"pools,omitempty"`
+
+	// Cluster contains Nexus cluster information.
+	Cluster *ClusterInfo `json:"cluster,omitempty"`
+
+	// RetryAfter is seconds to wait before retrying (for pending devices).
+	RetryAfter int `json:"retry_after,omitempty"`
+
+	// Message provides additional context about the response.
+	Message string `json:"message,omitempty"`
+}
+
+// bootstrap handles device bootstrap registration.
+// POST /api/v1/bootstrap
+func (s *Server) bootstrap(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Parse request body
+	var req BootstrapRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "invalid request body: malformed JSON")
+		return
+	}
+
+	// Validate required fields
+	if err := s.validateBootstrapRequest(&req); err != nil {
+		respondError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Normalize MAC address to uppercase with colons
+	normalizedMAC := normalizeMAC(req.MAC)
+
+	// Check if device already exists (by serial or MAC)
+	existingDevice, err := s.deviceStore.GetDeviceBySerial(ctx, req.Serial)
+	if err != nil && err != store.ErrDeviceNotFound {
+		respondError(w, http.StatusInternalServerError, "failed to check device registration")
+		return
+	}
+
+	if existingDevice == nil {
+		// Also check by MAC
+		existingDevice, err = s.deviceStore.GetDeviceByMAC(ctx, normalizedMAC)
+		if err != nil && err != store.ErrDeviceNotFound {
+			respondError(w, http.StatusInternalServerError, "failed to check device registration")
+			return
+		}
+	}
+
+	now := time.Now()
+	var device *store.Device
+
+	if existingDevice != nil {
+		// Re-registration: update last seen and any changed fields
+		device = existingDevice
+		device.LastSeen = now
+
+		// Update mutable fields if provided
+		if req.Firmware != "" {
+			device.Firmware = req.Firmware
+		}
+		if req.PublicKey != "" {
+			device.PublicKey = req.PublicKey
+		}
+		if req.Model != "" && device.Model == "" {
+			device.Model = req.Model
+		}
+	} else {
+		// New registration
+		nodeID := generateNodeID(req.Serial, normalizedMAC)
+
+		device = &store.Device{
+			NodeID:    nodeID,
+			Serial:    req.Serial,
+			MAC:       normalizedMAC,
+			Model:     req.Model,
+			Firmware:  req.Firmware,
+			PublicKey: req.PublicKey,
+			Status:    store.DeviceStatusPending,
+			FirstSeen: now,
+			LastSeen:  now,
+		}
+	}
+
+	// Save the device
+	if err := s.deviceStore.SaveDevice(ctx, device); err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to save device registration")
+		return
+	}
+
+	// Build response based on device status
+	response := s.buildBootstrapResponse(ctx, device)
+
+	// Return appropriate status code
+	statusCode := http.StatusOK
+	if existingDevice == nil {
+		statusCode = http.StatusCreated
+	}
+
+	respondJSON(w, statusCode, response)
+}
+
+// validateBootstrapRequest validates the bootstrap request fields.
+func (s *Server) validateBootstrapRequest(req *BootstrapRequest) error {
+	// Validate serial number
+	if err := validation.ValidateSerialNumber(req.Serial); err != nil {
+		return err
+	}
+
+	// Validate MAC address
+	if _, err := validation.ValidateMACAddress(req.MAC); err != nil {
+		return err
+	}
+
+	// Validate model if provided
+	if req.Model != "" {
+		if len(req.Model) > 64 {
+			return validation.NewValidationError("model", req.Model, "model exceeds maximum length of 64", validation.ErrValueTooLong)
+		}
+	}
+
+	// Validate firmware version if provided
+	if req.Firmware != "" {
+		if len(req.Firmware) > 64 {
+			return validation.NewValidationError("firmware", req.Firmware, "firmware version exceeds maximum length of 64", validation.ErrValueTooLong)
+		}
+	}
+
+	// Validate public key if provided (basic length check)
+	if req.PublicKey != "" {
+		if len(req.PublicKey) > 4096 {
+			return validation.NewValidationError("public_key", "", "public key exceeds maximum length of 4096", validation.ErrValueTooLong)
+		}
+	}
+
+	return nil
+}
+
+// buildBootstrapResponse constructs the response based on device state.
+func (s *Server) buildBootstrapResponse(ctx context.Context, device *store.Device) *BootstrapResponse {
+	response := &BootstrapResponse{
+		NodeID: device.NodeID,
+		Status: string(device.Status),
+	}
+
+	if device.Status == store.DeviceStatusPending {
+		// Device is pending configuration
+		response.RetryAfter = 30 // Check again in 30 seconds
+		response.Message = "Device registered, awaiting configuration"
+		return response
+	}
+
+	// Device is configured - include full configuration
+	response.SiteID = device.SiteID
+	response.Role = string(device.Role)
+
+	// Add partner info if available
+	if device.PartnerNodeID != "" {
+		response.Partner = &PartnerInfo{
+			NodeID: device.PartnerNodeID,
+			Status: "unknown", // Would need to check partner status
+		}
+	}
+
+	// Add assigned pools with their subnet assignments
+	if len(device.AssignedPools) > 0 {
+		response.Pools = s.getPoolAssignments(ctx, device)
+	}
+
+	// Add cluster info
+	response.Cluster = s.getClusterInfo(ctx)
+
+	response.Message = "Device configured successfully"
+	return response
+}
+
+// getPoolAssignments retrieves pool assignments for a device.
+func (s *Server) getPoolAssignments(ctx context.Context, device *store.Device) []PoolAssignment {
+	assignments := make([]PoolAssignment, 0, len(device.AssignedPools))
+
+	for _, poolID := range device.AssignedPools {
+		pool, err := s.poolStore.GetPool(ctx, poolID)
+		if err != nil {
+			continue // Skip pools that can't be found
+		}
+
+		assignment := PoolAssignment{
+			PoolID: poolID,
+			CIDR:   pool.CIDR.String(),
+		}
+
+		// Get subnets assigned to this node from the hashring
+		if s.ring != nil {
+			subnets, err := s.ring.ListPoolSubnetsAtNode(hashring.NodeID(device.NodeID))
+			if err == nil {
+				if poolSubnets, ok := subnets[hashring.PoolID(poolID)]; ok {
+					for _, subnet := range poolSubnets {
+						assignment.Subnets = append(assignment.Subnets, subnet.String())
+					}
+				}
+			}
+		}
+
+		assignments = append(assignments, assignment)
+	}
+
+	return assignments
+}
+
+// getClusterInfo retrieves current cluster information.
+func (s *Server) getClusterInfo(ctx context.Context) *ClusterInfo {
+	info := &ClusterInfo{
+		Peers: []string{}, // Would be populated from cluster state
+	}
+
+	// Get node list from nodeStore
+	nodes, err := s.nodeStore.ListNodes(ctx)
+	if err == nil {
+		for _, node := range nodes {
+			if addr, ok := node.Metadata["address"]; ok {
+				info.Peers = append(info.Peers, addr)
+			}
+		}
+	}
+
+	return info
+}
+
+// generateNodeID creates a deterministic node ID from serial and MAC.
+func generateNodeID(serial, mac string) string {
+	// Create a deterministic ID by hashing serial + MAC
+	input := serial + ":" + mac
+	hash := sha256.Sum256([]byte(input))
+	// Use first 8 bytes (16 hex chars) for a shorter ID
+	return "node-" + hex.EncodeToString(hash[:8])
+}
+
+// normalizeMAC converts a MAC address to uppercase with colons.
+func normalizeMAC(mac string) string {
+	// Remove any existing separators
+	mac = strings.ReplaceAll(mac, "-", "")
+	mac = strings.ReplaceAll(mac, ":", "")
+	mac = strings.ReplaceAll(mac, ".", "")
+	mac = strings.ToUpper(mac)
+
+	// Insert colons
+	if len(mac) == 12 {
+		return mac[0:2] + ":" + mac[2:4] + ":" + mac[4:6] + ":" +
+			mac[6:8] + ":" + mac[8:10] + ":" + mac[10:12]
+	}
+
+	return mac
+}
+
+// DeviceResponse represents a device in API responses.
+type DeviceResponse struct {
+	NodeID        string            `json:"node_id"`
+	Serial        string            `json:"serial"`
+	MAC           string            `json:"mac"`
+	Model         string            `json:"model,omitempty"`
+	Firmware      string            `json:"firmware,omitempty"`
+	Status        string            `json:"status"`
+	SiteID        string            `json:"site_id,omitempty"`
+	Role          string            `json:"role,omitempty"`
+	PartnerNodeID string            `json:"partner_node_id,omitempty"`
+	AssignedPools []string          `json:"assigned_pools,omitempty"`
+	FirstSeen     time.Time         `json:"first_seen"`
+	LastSeen      time.Time         `json:"last_seen"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+}
+
+// listDevices returns all registered devices.
+// GET /api/v1/devices
+func (s *Server) listDevices(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Optional filter by site_id
+	siteID := r.URL.Query().Get("site_id")
+	// Optional filter by status
+	statusFilter := r.URL.Query().Get("status")
+
+	var devices []*store.Device
+	var err error
+
+	if siteID != "" {
+		devices, err = s.deviceStore.ListDevicesBySite(ctx, siteID)
+	} else {
+		devices, err = s.deviceStore.ListDevices(ctx)
+	}
+
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to list devices")
+		return
+	}
+
+	// Apply status filter if provided
+	var filteredDevices []*store.Device
+	if statusFilter != "" {
+		for _, d := range devices {
+			if string(d.Status) == statusFilter {
+				filteredDevices = append(filteredDevices, d)
+			}
+		}
+	} else {
+		filteredDevices = devices
+	}
+
+	response := make([]DeviceResponse, 0, len(filteredDevices))
+	for _, d := range filteredDevices {
+		response = append(response, deviceToResponse(d))
+	}
+
+	respondJSON(w, http.StatusOK, map[string]interface{}{
+		"devices": response,
+		"count":   len(response),
+	})
+}
+
+// getDevice returns a specific device by node ID.
+// GET /api/v1/devices/{node_id}
+func (s *Server) getDevice(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Get node_id from URL path using gorilla/mux
+	vars := mux.Vars(r)
+	nodeID := vars["node_id"]
+
+	if nodeID == "" {
+		respondError(w, http.StatusBadRequest, "node_id is required")
+		return
+	}
+
+	device, err := s.deviceStore.GetDevice(ctx, nodeID)
+	if err == store.ErrDeviceNotFound {
+		respondError(w, http.StatusNotFound, "device not found")
+		return
+	}
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to get device")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, deviceToResponse(device))
+}
+
+// deviceToResponse converts a store.Device to API response format.
+func deviceToResponse(d *store.Device) DeviceResponse {
+	return DeviceResponse{
+		NodeID:        d.NodeID,
+		Serial:        d.Serial,
+		MAC:           d.MAC,
+		Model:         d.Model,
+		Firmware:      d.Firmware,
+		Status:        string(d.Status),
+		SiteID:        d.SiteID,
+		Role:          string(d.Role),
+		PartnerNodeID: d.PartnerNodeID,
+		AssignedPools: d.AssignedPools,
+		FirstSeen:     d.FirstSeen,
+		LastSeen:      d.LastSeen,
+		Metadata:      d.Metadata,
+	}
+}

--- a/internal/api/bootstrap_test.go
+++ b/internal/api/bootstrap_test.go
@@ -1,0 +1,680 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/codelaboratoryltd/nexus/internal/hashring"
+	"github.com/codelaboratoryltd/nexus/internal/store"
+)
+
+// setupTestServerWithDevices creates a test server with device store support.
+func setupTestServerWithDevices() (*Server, *mockPoolStore, *mockNodeStore, *mockAllocationStore, *store.InMemoryDeviceStore) {
+	ring := hashring.NewVirtualNodesHashRing()
+	poolStore := newMockPoolStore()
+	nodeStore := newMockNodeStore()
+	allocStore := newMockAllocationStore()
+	deviceStore := store.NewInMemoryDeviceStore()
+
+	server := NewServerWithDevices(ring, poolStore, nodeStore, allocStore, deviceStore)
+	return server, poolStore, nodeStore, allocStore, deviceStore
+}
+
+func TestBootstrap_NewDevice(t *testing.T) {
+	server, _, _, _, _ := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	body := `{
+		"serial": "GPON12345678",
+		"mac": "00:11:22:33:44:55",
+		"model": "OLT-BNG-1000",
+		"firmware": "1.0.0"
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("bootstrap new device returned status %d, want %d: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+
+	var response BootstrapResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if response.NodeID == "" {
+		t.Error("bootstrap response missing node_id")
+	}
+
+	if response.Status != "pending" {
+		t.Errorf("bootstrap response status = %s, want pending", response.Status)
+	}
+
+	if response.RetryAfter != 30 {
+		t.Errorf("bootstrap response retry_after = %d, want 30", response.RetryAfter)
+	}
+}
+
+func TestBootstrap_ReRegistration(t *testing.T) {
+	server, _, _, _, deviceStore := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	// First registration
+	body := `{
+		"serial": "GPON12345678",
+		"mac": "00:11:22:33:44:55",
+		"firmware": "1.0.0"
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("first bootstrap returned status %d: %s", w.Code, w.Body.String())
+	}
+
+	var firstResponse BootstrapResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &firstResponse); err != nil {
+		t.Fatalf("Failed to unmarshal first response: %v", err)
+	}
+
+	// Wait a moment to ensure LastSeen will be different
+	time.Sleep(10 * time.Millisecond)
+
+	// Re-registration with updated firmware
+	body = `{
+		"serial": "GPON12345678",
+		"mac": "00:11:22:33:44:55",
+		"firmware": "1.1.0"
+	}`
+	req = httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// Re-registration should return 200 OK, not 201 Created
+	if w.Code != http.StatusOK {
+		t.Errorf("re-registration returned status %d, want %d: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var secondResponse BootstrapResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &secondResponse); err != nil {
+		t.Fatalf("Failed to unmarshal second response: %v", err)
+	}
+
+	// Node ID should be the same
+	if secondResponse.NodeID != firstResponse.NodeID {
+		t.Errorf("re-registration changed node_id from %s to %s", firstResponse.NodeID, secondResponse.NodeID)
+	}
+
+	// Verify firmware was updated in store
+	device, err := deviceStore.GetDeviceBySerial(nil, "GPON12345678")
+	if err != nil {
+		t.Fatalf("Failed to get device: %v", err)
+	}
+	if device.Firmware != "1.1.0" {
+		t.Errorf("device firmware = %s, want 1.1.0", device.Firmware)
+	}
+}
+
+func TestBootstrap_MissingSerial(t *testing.T) {
+	server, _, _, _, _ := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	body := `{
+		"mac": "00:11:22:33:44:55"
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("bootstrap without serial returned status %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestBootstrap_MissingMAC(t *testing.T) {
+	server, _, _, _, _ := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	body := `{
+		"serial": "GPON12345678"
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("bootstrap without MAC returned status %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestBootstrap_InvalidMAC(t *testing.T) {
+	server, _, _, _, _ := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	body := `{
+		"serial": "GPON12345678",
+		"mac": "not-a-mac"
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("bootstrap with invalid MAC returned status %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestBootstrap_InvalidSerial(t *testing.T) {
+	server, _, _, _, _ := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	body := `{
+		"serial": "ab",
+		"mac": "00:11:22:33:44:55"
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("bootstrap with invalid serial returned status %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestBootstrap_InvalidJSON(t *testing.T) {
+	server, _, _, _, _ := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	body := `{invalid json}`
+	req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("bootstrap with invalid JSON returned status %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestBootstrap_MACFormatNormalization(t *testing.T) {
+	testCases := []struct {
+		name        string
+		inputMAC    string
+		expectedMAC string
+		serial      string
+	}{
+		{"colon separated", "00:11:22:33:44:55", "00:11:22:33:44:55", "GPON00000001"},
+		{"dash separated", "00-11-22-33-44-66", "00:11:22:33:44:66", "GPON00000002"},
+		{"no separator", "001122334477", "00:11:22:33:44:77", "GPON00000003"},
+		{"lowercase", "aa:bb:cc:dd:ee:ff", "AA:BB:CC:DD:EE:FF", "GPON00000004"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create fresh server for each test to avoid MAC collision
+			server, _, _, _, deviceStore := setupTestServerWithDevices()
+			router := mux.NewRouter()
+			server.RegisterRoutes(router)
+
+			body := `{
+				"serial": "` + tc.serial + `",
+				"mac": "` + tc.inputMAC + `"
+			}`
+			req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusCreated {
+				t.Errorf("bootstrap returned status %d: %s", w.Code, w.Body.String())
+				return
+			}
+
+			// Verify MAC was normalized
+			device, err := deviceStore.GetDeviceBySerial(nil, tc.serial)
+			if err != nil {
+				t.Fatalf("Failed to get device: %v", err)
+			}
+			if device.MAC != tc.expectedMAC {
+				t.Errorf("device MAC = %s, want %s", device.MAC, tc.expectedMAC)
+			}
+		})
+	}
+}
+
+func TestBootstrap_DeterministicNodeID(t *testing.T) {
+	server, _, _, _, _ := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	body := `{
+		"serial": "GPON12345678",
+		"mac": "00:11:22:33:44:55"
+	}`
+
+	// First request
+	req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	var firstResponse BootstrapResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &firstResponse); err != nil {
+		t.Fatalf("Failed to unmarshal first response: %v", err)
+	}
+
+	// Delete the device to simulate a fresh registration
+	server.deviceStore.DeleteDevice(nil, firstResponse.NodeID)
+
+	// Second request with same serial/MAC
+	req = httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	var secondResponse BootstrapResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &secondResponse); err != nil {
+		t.Fatalf("Failed to unmarshal second response: %v", err)
+	}
+
+	// Node ID should be the same since it's deterministic based on serial + MAC
+	if secondResponse.NodeID != firstResponse.NodeID {
+		t.Errorf("deterministic node_id mismatch: got %s, expected %s", secondResponse.NodeID, firstResponse.NodeID)
+	}
+}
+
+func TestListDevices_Empty(t *testing.T) {
+	server, _, _, _, _ := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	req := httptest.NewRequest("GET", "/api/v1/devices", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("list devices returned status %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	devices, ok := response["devices"].([]interface{})
+	if !ok {
+		t.Fatal("Response does not contain devices array")
+	}
+	if len(devices) != 0 {
+		t.Errorf("Expected empty devices, got %d", len(devices))
+	}
+}
+
+func TestListDevices_WithDevices(t *testing.T) {
+	server, _, _, _, _ := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	// Register two devices
+	for i, serial := range []string{"GPON11111111", "GPON22222222"} {
+		body := `{
+			"serial": "` + serial + `",
+			"mac": "00:11:22:33:44:5` + string(rune('0'+i)) + `"
+		}`
+		req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("bootstrap %d returned status %d", i, w.Code)
+		}
+	}
+
+	// List devices
+	req := httptest.NewRequest("GET", "/api/v1/devices", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("list devices returned status %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	count, ok := response["count"].(float64)
+	if !ok || count != 2 {
+		t.Errorf("Expected count 2, got %v", response["count"])
+	}
+}
+
+func TestListDevices_FilterByStatus(t *testing.T) {
+	server, _, _, _, deviceStore := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	// Register a device (will be pending)
+	body := `{
+		"serial": "GPON11111111",
+		"mac": "00:11:22:33:44:55"
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	var response BootstrapResponse
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	// Manually update one device to configured status
+	device, _ := deviceStore.GetDevice(nil, response.NodeID)
+	device.Status = store.DeviceStatusConfigured
+	deviceStore.SaveDevice(nil, device)
+
+	// Register another device (will remain pending)
+	body = `{
+		"serial": "GPON22222222",
+		"mac": "00:11:22:33:44:56"
+	}`
+	req = httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Filter by pending status
+	req = httptest.NewRequest("GET", "/api/v1/devices?status=pending", nil)
+	w = httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("list devices returned status %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var listResponse map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &listResponse); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	count, ok := listResponse["count"].(float64)
+	if !ok || count != 1 {
+		t.Errorf("Expected count 1 for pending devices, got %v", listResponse["count"])
+	}
+}
+
+func TestGetDevice_Found(t *testing.T) {
+	server, _, _, _, _ := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	// Register a device
+	body := `{
+		"serial": "GPON12345678",
+		"mac": "00:11:22:33:44:55",
+		"model": "OLT-BNG-1000"
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	var bootstrapResponse BootstrapResponse
+	json.Unmarshal(w.Body.Bytes(), &bootstrapResponse)
+
+	// Get the device
+	req = httptest.NewRequest("GET", "/api/v1/devices/"+bootstrapResponse.NodeID, nil)
+	w = httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("get device returned status %d, want %d: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var deviceResponse DeviceResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &deviceResponse); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if deviceResponse.NodeID != bootstrapResponse.NodeID {
+		t.Errorf("device node_id = %s, want %s", deviceResponse.NodeID, bootstrapResponse.NodeID)
+	}
+	if deviceResponse.Serial != "GPON12345678" {
+		t.Errorf("device serial = %s, want GPON12345678", deviceResponse.Serial)
+	}
+	if deviceResponse.Model != "OLT-BNG-1000" {
+		t.Errorf("device model = %s, want OLT-BNG-1000", deviceResponse.Model)
+	}
+}
+
+func TestGetDevice_NotFound(t *testing.T) {
+	server, _, _, _, _ := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	req := httptest.NewRequest("GET", "/api/v1/devices/nonexistent-node", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("get nonexistent device returned status %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestNormalizeMAC(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"00:11:22:33:44:55", "00:11:22:33:44:55"},
+		{"00-11-22-33-44-55", "00:11:22:33:44:55"},
+		{"001122334455", "00:11:22:33:44:55"},
+		{"aa:bb:cc:dd:ee:ff", "AA:BB:CC:DD:EE:FF"},
+		{"AA:BB:CC:DD:EE:FF", "AA:BB:CC:DD:EE:FF"},
+		{"aabb.ccdd.eeff", "AA:BB:CC:DD:EE:FF"}, // Cisco format
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := normalizeMAC(tc.input)
+			if result != tc.expected {
+				t.Errorf("normalizeMAC(%s) = %s, want %s", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateNodeID(t *testing.T) {
+	// Test determinism
+	serial := "GPON12345678"
+	mac := "00:11:22:33:44:55"
+
+	id1 := generateNodeID(serial, mac)
+	id2 := generateNodeID(serial, mac)
+
+	if id1 != id2 {
+		t.Errorf("generateNodeID not deterministic: %s != %s", id1, id2)
+	}
+
+	// Test prefix
+	if !strings.HasPrefix(id1, "node-") {
+		t.Errorf("generateNodeID should have 'node-' prefix, got %s", id1)
+	}
+
+	// Test uniqueness with different inputs
+	id3 := generateNodeID("GPON87654321", mac)
+	if id1 == id3 {
+		t.Error("generateNodeID should produce different IDs for different serials")
+	}
+
+	id4 := generateNodeID(serial, "AA:BB:CC:DD:EE:FF")
+	if id1 == id4 {
+		t.Error("generateNodeID should produce different IDs for different MACs")
+	}
+}
+
+func TestBootstrap_ConfiguredDevice(t *testing.T) {
+	server, _, _, _, deviceStore := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	// Register a device
+	body := `{
+		"serial": "GPON12345678",
+		"mac": "00:11:22:33:44:55"
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	var firstResponse BootstrapResponse
+	json.Unmarshal(w.Body.Bytes(), &firstResponse)
+
+	// Manually update device to configured status with pool assignments
+	device, _ := deviceStore.GetDevice(nil, firstResponse.NodeID)
+	device.Status = store.DeviceStatusConfigured
+	device.SiteID = "site-001"
+	device.Role = store.DeviceRoleActive
+	device.PartnerNodeID = "node-partner"
+	device.AssignedPools = []string{"pool1"}
+	deviceStore.SaveDevice(nil, device)
+
+	// Re-bootstrap should return configured device info
+	req = httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("bootstrap configured device returned status %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var response BootstrapResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if response.Status != "configured" {
+		t.Errorf("response status = %s, want configured", response.Status)
+	}
+	if response.SiteID != "site-001" {
+		t.Errorf("response site_id = %s, want site-001", response.SiteID)
+	}
+	if response.Role != "active" {
+		t.Errorf("response role = %s, want active", response.Role)
+	}
+	if response.Partner == nil {
+		t.Error("response should have partner info")
+	} else if response.Partner.NodeID != "node-partner" {
+		t.Errorf("response partner node_id = %s, want node-partner", response.Partner.NodeID)
+	}
+	if response.RetryAfter != 0 {
+		t.Errorf("configured device should not have retry_after, got %d", response.RetryAfter)
+	}
+}
+
+func TestBootstrap_WithoutDeviceStore(t *testing.T) {
+	// Test that bootstrap endpoint is not available without device store
+	server, _, _, _ := setupTestServer()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	body := `{
+		"serial": "GPON12345678",
+		"mac": "00:11:22:33:44:55"
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// Should get 404 since route is not registered without device store
+	if w.Code != http.StatusNotFound && w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("bootstrap without device store returned status %d, want 404 or 405", w.Code)
+	}
+}
+
+func TestBootstrap_LongFirmwareVersion(t *testing.T) {
+	server, _, _, _, _ := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	// Create a firmware string longer than 64 characters
+	longFirmware := strings.Repeat("x", 65)
+	body := `{
+		"serial": "GPON12345678",
+		"mac": "00:11:22:33:44:55",
+		"firmware": "` + longFirmware + `"
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("bootstrap with long firmware returned status %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestBootstrap_LongPublicKey(t *testing.T) {
+	server, _, _, _, _ := setupTestServerWithDevices()
+	router := mux.NewRouter()
+	server.RegisterRoutes(router)
+
+	// Create a public key string longer than 4096 characters
+	longKey := strings.Repeat("x", 4097)
+	body := `{
+		"serial": "GPON12345678",
+		"mac": "00:11:22:33:44:55",
+		"public_key": "` + longKey + `"
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("bootstrap with long public_key returned status %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}

--- a/internal/store/device.go
+++ b/internal/store/device.go
@@ -1,0 +1,449 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	ds "github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
+)
+
+// DeviceStatus represents the registration status of a device.
+type DeviceStatus string
+
+const (
+	// DeviceStatusPending indicates the device is awaiting configuration.
+	DeviceStatusPending DeviceStatus = "pending"
+	// DeviceStatusConfigured indicates the device has been assigned a site and configuration.
+	DeviceStatusConfigured DeviceStatus = "configured"
+)
+
+// DeviceRole represents the role of a device in an HA pair.
+type DeviceRole string
+
+const (
+	// DeviceRoleActive indicates the device is the active/primary device.
+	DeviceRoleActive DeviceRole = "active"
+	// DeviceRoleStandby indicates the device is the standby/backup device.
+	DeviceRoleStandby DeviceRole = "standby"
+)
+
+// Device represents an OLT-BNG device registered with Nexus.
+type Device struct {
+	// NodeID is the unique identifier assigned by Nexus.
+	NodeID string `json:"node_id" cbor:"node_id"`
+
+	// Serial is the hardware serial number.
+	Serial string `json:"serial" cbor:"serial"`
+
+	// MAC is the primary MAC address.
+	MAC string `json:"mac" cbor:"mac"`
+
+	// Model is the device model identifier.
+	Model string `json:"model,omitempty" cbor:"model"`
+
+	// Firmware is the current firmware version.
+	Firmware string `json:"firmware,omitempty" cbor:"firmware"`
+
+	// PublicKey is the device's public key for mTLS (future use).
+	PublicKey string `json:"public_key,omitempty" cbor:"public_key"`
+
+	// Status is the current registration status.
+	Status DeviceStatus `json:"status" cbor:"status"`
+
+	// SiteID is the assigned site identifier (if configured).
+	SiteID string `json:"site_id,omitempty" cbor:"site_id"`
+
+	// Role is the device role in an HA pair (if configured).
+	Role DeviceRole `json:"role,omitempty" cbor:"role"`
+
+	// PartnerNodeID is the node ID of the HA partner (if configured).
+	PartnerNodeID string `json:"partner_node_id,omitempty" cbor:"partner_node_id"`
+
+	// AssignedPools is the list of pool IDs assigned to this device.
+	AssignedPools []string `json:"assigned_pools,omitempty" cbor:"assigned_pools"`
+
+	// FirstSeen is when the device was first registered.
+	FirstSeen time.Time `json:"first_seen" cbor:"first_seen"`
+
+	// LastSeen is when the device last bootstrapped.
+	LastSeen time.Time `json:"last_seen" cbor:"last_seen"`
+
+	// Metadata holds additional device metadata.
+	Metadata map[string]string `json:"metadata,omitempty" cbor:"metadata"`
+}
+
+// DeviceStore manages device registrations.
+type DeviceStore interface {
+	// SaveDevice persists a device registration.
+	SaveDevice(ctx context.Context, device *Device) error
+
+	// GetDevice retrieves a device by node ID.
+	GetDevice(ctx context.Context, nodeID string) (*Device, error)
+
+	// GetDeviceBySerial retrieves a device by serial number.
+	GetDeviceBySerial(ctx context.Context, serial string) (*Device, error)
+
+	// GetDeviceByMAC retrieves a device by MAC address.
+	GetDeviceByMAC(ctx context.Context, mac string) (*Device, error)
+
+	// ListDevices retrieves all registered devices.
+	ListDevices(ctx context.Context) ([]*Device, error)
+
+	// ListDevicesBySite retrieves all devices for a given site.
+	ListDevicesBySite(ctx context.Context, siteID string) ([]*Device, error)
+
+	// DeleteDevice removes a device registration.
+	DeleteDevice(ctx context.Context, nodeID string) error
+}
+
+// Errors for device operations.
+var (
+	ErrDeviceNotFound  = fmt.Errorf("device not found")
+	ErrDuplicateDevice = fmt.Errorf("device already exists")
+)
+
+// deviceStore is the datastore-backed implementation of DeviceStore.
+type deviceStore struct {
+	ds ds.Batching
+	mu sync.RWMutex
+
+	// Index maps for faster lookups
+	serialIndex map[string]string // serial -> nodeID
+	macIndex    map[string]string // mac -> nodeID
+}
+
+// NewDeviceStore creates a new device store with the given datastore.
+func NewDeviceStore(datastore ds.Batching) (DeviceStore, error) {
+	store := &deviceStore{
+		ds:          datastore,
+		serialIndex: make(map[string]string),
+		macIndex:    make(map[string]string),
+	}
+
+	// Rebuild indexes from existing data
+	if err := store.rebuildIndexes(context.Background()); err != nil {
+		return nil, fmt.Errorf("failed to rebuild device indexes: %w", err)
+	}
+
+	return store, nil
+}
+
+// deviceKeyPrefix is the datastore key prefix for devices.
+const deviceKeyPrefix = "/devices/"
+
+// deviceKey returns the datastore key for a device.
+func deviceKey(nodeID string) ds.Key {
+	return ds.NewKey(deviceKeyPrefix + nodeID)
+}
+
+// rebuildIndexes rebuilds the in-memory indexes from the datastore.
+func (s *deviceStore) rebuildIndexes(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	q := query.Query{
+		Prefix: deviceKeyPrefix,
+	}
+
+	results, err := s.ds.Query(ctx, q)
+	if err != nil {
+		return err
+	}
+	defer results.Close()
+
+	for result := range results.Next() {
+		if result.Error != nil {
+			return result.Error
+		}
+
+		var device Device
+		if err := json.Unmarshal(result.Entry.Value, &device); err != nil {
+			continue // Skip invalid entries
+		}
+
+		if device.Serial != "" {
+			s.serialIndex[device.Serial] = device.NodeID
+		}
+		if device.MAC != "" {
+			s.macIndex[device.MAC] = device.NodeID
+		}
+	}
+
+	return nil
+}
+
+// SaveDevice persists a device registration.
+func (s *deviceStore) SaveDevice(ctx context.Context, device *Device) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := json.Marshal(device)
+	if err != nil {
+		return fmt.Errorf("failed to marshal device: %w", err)
+	}
+
+	if err := s.ds.Put(ctx, deviceKey(device.NodeID), data); err != nil {
+		return fmt.Errorf("failed to save device: %w", err)
+	}
+
+	// Update indexes
+	if device.Serial != "" {
+		s.serialIndex[device.Serial] = device.NodeID
+	}
+	if device.MAC != "" {
+		s.macIndex[device.MAC] = device.NodeID
+	}
+
+	return nil
+}
+
+// GetDevice retrieves a device by node ID.
+func (s *deviceStore) GetDevice(ctx context.Context, nodeID string) (*Device, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	data, err := s.ds.Get(ctx, deviceKey(nodeID))
+	if err == ds.ErrNotFound {
+		return nil, ErrDeviceNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get device: %w", err)
+	}
+
+	var device Device
+	if err := json.Unmarshal(data, &device); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal device: %w", err)
+	}
+
+	return &device, nil
+}
+
+// GetDeviceBySerial retrieves a device by serial number.
+func (s *deviceStore) GetDeviceBySerial(ctx context.Context, serial string) (*Device, error) {
+	s.mu.RLock()
+	nodeID, ok := s.serialIndex[serial]
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, ErrDeviceNotFound
+	}
+
+	return s.GetDevice(ctx, nodeID)
+}
+
+// GetDeviceByMAC retrieves a device by MAC address.
+func (s *deviceStore) GetDeviceByMAC(ctx context.Context, mac string) (*Device, error) {
+	s.mu.RLock()
+	nodeID, ok := s.macIndex[mac]
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, ErrDeviceNotFound
+	}
+
+	return s.GetDevice(ctx, nodeID)
+}
+
+// ListDevices retrieves all registered devices.
+func (s *deviceStore) ListDevices(ctx context.Context) ([]*Device, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	q := query.Query{
+		Prefix: deviceKeyPrefix,
+	}
+
+	results, err := s.ds.Query(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query devices: %w", err)
+	}
+	defer results.Close()
+
+	var devices []*Device
+	for result := range results.Next() {
+		if result.Error != nil {
+			return nil, result.Error
+		}
+
+		var device Device
+		if err := json.Unmarshal(result.Entry.Value, &device); err != nil {
+			continue // Skip invalid entries
+		}
+		devices = append(devices, &device)
+	}
+
+	return devices, nil
+}
+
+// ListDevicesBySite retrieves all devices for a given site.
+func (s *deviceStore) ListDevicesBySite(ctx context.Context, siteID string) ([]*Device, error) {
+	devices, err := s.ListDevices(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var siteDevices []*Device
+	for _, d := range devices {
+		if d.SiteID == siteID {
+			siteDevices = append(siteDevices, d)
+		}
+	}
+
+	return siteDevices, nil
+}
+
+// DeleteDevice removes a device registration.
+func (s *deviceStore) DeleteDevice(ctx context.Context, nodeID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Get device first to clean up indexes
+	data, err := s.ds.Get(ctx, deviceKey(nodeID))
+	if err == ds.ErrNotFound {
+		return nil // Already deleted
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get device for deletion: %w", err)
+	}
+
+	var device Device
+	if err := json.Unmarshal(data, &device); err == nil {
+		// Clean up indexes
+		if device.Serial != "" {
+			delete(s.serialIndex, device.Serial)
+		}
+		if device.MAC != "" {
+			delete(s.macIndex, device.MAC)
+		}
+	}
+
+	if err := s.ds.Delete(ctx, deviceKey(nodeID)); err != nil {
+		return fmt.Errorf("failed to delete device: %w", err)
+	}
+
+	return nil
+}
+
+// InMemoryDeviceStore is a simple in-memory implementation for testing.
+type InMemoryDeviceStore struct {
+	mu      sync.RWMutex
+	devices map[string]*Device
+	serial  map[string]string
+	mac     map[string]string
+}
+
+// NewInMemoryDeviceStore creates a new in-memory device store.
+func NewInMemoryDeviceStore() *InMemoryDeviceStore {
+	return &InMemoryDeviceStore{
+		devices: make(map[string]*Device),
+		serial:  make(map[string]string),
+		mac:     make(map[string]string),
+	}
+}
+
+func (s *InMemoryDeviceStore) SaveDevice(ctx context.Context, device *Device) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Make a copy to avoid external mutations
+	d := *device
+	s.devices[d.NodeID] = &d
+
+	if d.Serial != "" {
+		s.serial[d.Serial] = d.NodeID
+	}
+	if d.MAC != "" {
+		s.mac[d.MAC] = d.NodeID
+	}
+
+	return nil
+}
+
+func (s *InMemoryDeviceStore) GetDevice(ctx context.Context, nodeID string) (*Device, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	device, ok := s.devices[nodeID]
+	if !ok {
+		return nil, ErrDeviceNotFound
+	}
+
+	// Return a copy
+	d := *device
+	return &d, nil
+}
+
+func (s *InMemoryDeviceStore) GetDeviceBySerial(ctx context.Context, serial string) (*Device, error) {
+	s.mu.RLock()
+	nodeID, ok := s.serial[serial]
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, ErrDeviceNotFound
+	}
+
+	return s.GetDevice(ctx, nodeID)
+}
+
+func (s *InMemoryDeviceStore) GetDeviceByMAC(ctx context.Context, mac string) (*Device, error) {
+	s.mu.RLock()
+	nodeID, ok := s.mac[mac]
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, ErrDeviceNotFound
+	}
+
+	return s.GetDevice(ctx, nodeID)
+}
+
+func (s *InMemoryDeviceStore) ListDevices(ctx context.Context) ([]*Device, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	devices := make([]*Device, 0, len(s.devices))
+	for _, d := range s.devices {
+		device := *d
+		devices = append(devices, &device)
+	}
+
+	return devices, nil
+}
+
+func (s *InMemoryDeviceStore) ListDevicesBySite(ctx context.Context, siteID string) ([]*Device, error) {
+	devices, err := s.ListDevices(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var siteDevices []*Device
+	for _, d := range devices {
+		if d.SiteID == siteID {
+			siteDevices = append(siteDevices, d)
+		}
+	}
+
+	return siteDevices, nil
+}
+
+func (s *InMemoryDeviceStore) DeleteDevice(ctx context.Context, nodeID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	device, ok := s.devices[nodeID]
+	if ok {
+		if device.Serial != "" {
+			delete(s.serial, device.Serial)
+		}
+		if device.MAC != "" {
+			delete(s.mac, device.MAC)
+		}
+		delete(s.devices, nodeID)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Implements the Bootstrap API for OLT-BNG nodes to register with Nexus and receive initial configuration.

- Add `POST /api/v1/bootstrap` endpoint for device registration
- Add `GET /api/v1/devices` endpoint to list registered devices  
- Add `GET /api/v1/devices/{node_id}` endpoint to get specific device
- Add `DeviceStore` interface and implementation for device persistence

## Key Features

- **Idempotent registration**: New devices get 201 Created, re-registration returns 200 OK
- **Device validation**: Serial number, MAC address, firmware version required
- **Deterministic node IDs**: Generated from serial+MAC hash for consistency
- **Pending state**: Unconfigured devices return `status: "pending"` with `retry_after`
- **MAC normalization**: Accepts various formats, stores as uppercase with colons

## API

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/api/v1/bootstrap` | POST | Register/re-register a device |
| `/api/v1/devices` | GET | List devices (`?status=`, `?site_id=` filters) |
| `/api/v1/devices/{node_id}` | GET | Get specific device |

## Test Plan

- [x] 25+ unit tests covering all endpoints
- [x] All 69 API tests pass
- [ ] Integration test with BNG ZTP client (Phase 2)

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/code)