### PR TITLE
feat(failure): Automatic node failure detection

### DIFF
--- a/internal/failure/detector.go
+++ b/internal/failure/detector.go
@@ -1,0 +1,436 @@
+// Package failure provides automatic detection of failed Nexus nodes in the cluster.
+// It monitors node heartbeats and detects when nodes exceed their best_before time,
+// triggering events for shard reassignment.
+package failure
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/codelaboratoryltd/nexus/internal/store"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// DefaultCheckInterval is the default interval for checking node health.
+	DefaultCheckInterval = 10 * time.Second
+
+	// DefaultFailureTimeout is the default timeout after which a node is considered failed.
+	// This is typically 3x the heartbeat interval (e.g., 10s heartbeat = 30s timeout).
+	DefaultFailureTimeout = 30 * time.Second
+
+	// DefaultGracePeriod is the time to wait before declaring a node failed after
+	// it first exceeds its best_before time. This prevents flapping.
+	DefaultGracePeriod = 5 * time.Second
+)
+
+// NodeFailedEvent represents an event emitted when a node failure is detected.
+type NodeFailedEvent struct {
+	NodeID       string
+	BestBefore   time.Time
+	DetectedAt   time.Time
+	TimeSinceDue time.Duration // How long past best_before the node was
+}
+
+// NodeStore is the interface for accessing node information.
+// This matches the store.NodeStore interface but is defined here for testability.
+type NodeStore interface {
+	ListNodes(ctx context.Context) ([]*store.Node, error)
+}
+
+// Config holds configuration for the failure detector.
+type Config struct {
+	// CheckInterval is how often to check for failed nodes.
+	CheckInterval time.Duration
+
+	// FailureTimeout is how long after best_before before a node is considered failed.
+	// This provides a grace period for network delays.
+	FailureTimeout time.Duration
+
+	// GracePeriod is the time a node must be continuously past its best_before
+	// before being declared failed. This prevents flapping.
+	GracePeriod time.Duration
+}
+
+// DefaultConfig returns a Config with sensible defaults.
+func DefaultConfig() Config {
+	return Config{
+		CheckInterval:  DefaultCheckInterval,
+		FailureTimeout: DefaultFailureTimeout,
+		GracePeriod:    DefaultGracePeriod,
+	}
+}
+
+// Metrics holds Prometheus metrics for the failure detector.
+type Metrics struct {
+	// NodesFailedTotal is a counter of total node failures detected.
+	NodesFailedTotal prometheus.Counter
+
+	// DetectionLatency measures the time from best_before to failure detection.
+	DetectionLatency prometheus.Histogram
+
+	// NodesMonitored is a gauge of nodes currently being monitored.
+	NodesMonitored prometheus.Gauge
+
+	// NodesHealthy is a gauge of nodes currently healthy (not expired).
+	NodesHealthy prometheus.Gauge
+
+	// NodesExpired is a gauge of nodes currently expired but not yet failed.
+	NodesExpired prometheus.Gauge
+
+	// CheckDuration measures how long each check cycle takes.
+	CheckDuration prometheus.Histogram
+}
+
+// NewMetrics creates and registers Prometheus metrics for the failure detector.
+func NewMetrics(registerer prometheus.Registerer) *Metrics {
+	m := &Metrics{
+		NodesFailedTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "nexus",
+			Subsystem: "failure_detector",
+			Name:      "nodes_failed_total",
+			Help:      "Total number of node failures detected.",
+		}),
+		DetectionLatency: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "nexus",
+			Subsystem: "failure_detector",
+			Name:      "detection_latency_seconds",
+			Help:      "Time from node best_before to failure detection.",
+			Buckets:   []float64{1, 5, 10, 30, 60, 120, 300},
+		}),
+		NodesMonitored: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "nexus",
+			Subsystem: "failure_detector",
+			Name:      "nodes_monitored",
+			Help:      "Number of nodes currently being monitored.",
+		}),
+		NodesHealthy: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "nexus",
+			Subsystem: "failure_detector",
+			Name:      "nodes_healthy",
+			Help:      "Number of nodes currently healthy (not expired).",
+		}),
+		NodesExpired: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "nexus",
+			Subsystem: "failure_detector",
+			Name:      "nodes_expired",
+			Help:      "Number of nodes currently expired but not yet failed.",
+		}),
+		CheckDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "nexus",
+			Subsystem: "failure_detector",
+			Name:      "check_duration_seconds",
+			Help:      "Duration of each node health check cycle.",
+			Buckets:   prometheus.DefBuckets,
+		}),
+	}
+
+	if registerer != nil {
+		registerer.MustRegister(
+			m.NodesFailedTotal,
+			m.DetectionLatency,
+			m.NodesMonitored,
+			m.NodesHealthy,
+			m.NodesExpired,
+			m.CheckDuration,
+		)
+	}
+
+	return m
+}
+
+// nodeState tracks the state of a node for failure detection.
+type nodeState struct {
+	// firstExpiredAt is when the node was first observed as expired.
+	// Used to implement grace period.
+	firstExpiredAt time.Time
+
+	// alreadyFailed indicates we've already emitted a failure event for this node.
+	alreadyFailed bool
+}
+
+// Detector monitors node health and detects failures.
+type Detector struct {
+	mu sync.Mutex
+
+	store   NodeStore
+	config  Config
+	metrics *Metrics
+
+	// nodeStates tracks the state of each node for failure detection.
+	nodeStates map[string]*nodeState
+
+	// onNodeFailed is called when a node failure is detected.
+	onNodeFailed func(event NodeFailedEvent)
+
+	// subscribers is a list of channels to notify on node failure.
+	subscribers []chan<- NodeFailedEvent
+
+	// running indicates whether the detector is currently running.
+	running bool
+
+	// stopCh is used to signal the detector to stop.
+	stopCh chan struct{}
+}
+
+// Option is a functional option for configuring the Detector.
+type Option func(*Detector)
+
+// WithConfig sets the detector configuration.
+func WithConfig(cfg Config) Option {
+	return func(d *Detector) {
+		d.config = cfg
+	}
+}
+
+// WithMetrics sets the Prometheus metrics for the detector.
+func WithMetrics(m *Metrics) Option {
+	return func(d *Detector) {
+		d.metrics = m
+	}
+}
+
+// WithCallback sets a callback function to be called when a node fails.
+func WithCallback(fn func(event NodeFailedEvent)) Option {
+	return func(d *Detector) {
+		d.onNodeFailed = fn
+	}
+}
+
+// NewDetector creates a new failure detector with the given node store and options.
+func NewDetector(nodeStore NodeStore, opts ...Option) *Detector {
+	d := &Detector{
+		store:      nodeStore,
+		config:     DefaultConfig(),
+		nodeStates: make(map[string]*nodeState),
+		stopCh:     make(chan struct{}),
+	}
+
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	return d
+}
+
+// Subscribe adds a channel to receive failure events.
+// The channel should be buffered to prevent blocking the detector.
+func (d *Detector) Subscribe(ch chan<- NodeFailedEvent) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.subscribers = append(d.subscribers, ch)
+}
+
+// Unsubscribe removes a channel from receiving failure events.
+func (d *Detector) Unsubscribe(ch chan<- NodeFailedEvent) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	for i, sub := range d.subscribers {
+		if sub == ch {
+			d.subscribers = append(d.subscribers[:i], d.subscribers[i+1:]...)
+			return
+		}
+	}
+}
+
+// Start begins the failure detection loop.
+// It returns immediately and runs the detector in a background goroutine.
+// The detector will run until Stop is called or the context is cancelled.
+func (d *Detector) Start(ctx context.Context) error {
+	d.mu.Lock()
+	if d.running {
+		d.mu.Unlock()
+		return nil
+	}
+	d.running = true
+	d.stopCh = make(chan struct{})
+	d.mu.Unlock()
+
+	go d.run(ctx)
+	return nil
+}
+
+// Stop stops the failure detection loop.
+func (d *Detector) Stop() {
+	d.mu.Lock()
+	if !d.running {
+		d.mu.Unlock()
+		return
+	}
+	d.running = false
+	close(d.stopCh)
+	d.mu.Unlock()
+}
+
+// IsRunning returns whether the detector is currently running.
+func (d *Detector) IsRunning() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.running
+}
+
+// run is the main detection loop.
+func (d *Detector) run(ctx context.Context) {
+	ticker := time.NewTicker(d.config.CheckInterval)
+	defer ticker.Stop()
+
+	// Do an initial check immediately
+	d.checkNodes(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			d.mu.Lock()
+			d.running = false
+			d.mu.Unlock()
+			return
+		case <-d.stopCh:
+			return
+		case <-ticker.C:
+			d.checkNodes(ctx)
+		}
+	}
+}
+
+// checkNodes checks all nodes and detects failures.
+func (d *Detector) checkNodes(ctx context.Context) {
+	startTime := time.Now()
+	defer func() {
+		if d.metrics != nil {
+			d.metrics.CheckDuration.Observe(time.Since(startTime).Seconds())
+		}
+	}()
+
+	nodes, err := d.store.ListNodes(ctx)
+	if err != nil {
+		// Log error but continue - don't want to crash the detector
+		return
+	}
+
+	now := time.Now()
+	healthy := 0
+	expired := 0
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Track which nodes we've seen this check
+	seenNodes := make(map[string]bool)
+
+	for _, node := range nodes {
+		seenNodes[node.ID] = true
+
+		// Get or create node state
+		state, exists := d.nodeStates[node.ID]
+		if !exists {
+			state = &nodeState{}
+			d.nodeStates[node.ID] = state
+		}
+
+		// Check if node has exceeded best_before
+		if now.After(node.BestBefore) {
+			// Node is expired
+			expired++
+
+			// If this is the first time we've seen it expired, record the time
+			if state.firstExpiredAt.IsZero() {
+				state.firstExpiredAt = now
+			}
+
+			// Check if we should declare failure (past grace period and not already failed)
+			gracePeriodExceeded := now.Sub(state.firstExpiredAt) >= d.config.GracePeriod
+			timeoutExceeded := now.Sub(node.BestBefore) >= d.config.FailureTimeout
+
+			if !state.alreadyFailed && (gracePeriodExceeded || timeoutExceeded) {
+				// Declare node as failed
+				state.alreadyFailed = true
+
+				event := NodeFailedEvent{
+					NodeID:       node.ID,
+					BestBefore:   node.BestBefore,
+					DetectedAt:   now,
+					TimeSinceDue: now.Sub(node.BestBefore),
+				}
+
+				// Update metrics
+				if d.metrics != nil {
+					d.metrics.NodesFailedTotal.Inc()
+					d.metrics.DetectionLatency.Observe(event.TimeSinceDue.Seconds())
+				}
+
+				// Emit event
+				d.emitFailure(event)
+			}
+		} else {
+			// Node is healthy - reset state
+			healthy++
+			state.firstExpiredAt = time.Time{}
+			state.alreadyFailed = false
+		}
+	}
+
+	// Clean up state for nodes that no longer exist
+	for nodeID := range d.nodeStates {
+		if !seenNodes[nodeID] {
+			delete(d.nodeStates, nodeID)
+		}
+	}
+
+	// Update metrics
+	if d.metrics != nil {
+		d.metrics.NodesMonitored.Set(float64(len(nodes)))
+		d.metrics.NodesHealthy.Set(float64(healthy))
+		d.metrics.NodesExpired.Set(float64(expired))
+	}
+}
+
+// emitFailure sends the failure event to all subscribers and callback.
+// Must be called with d.mu held.
+func (d *Detector) emitFailure(event NodeFailedEvent) {
+	// Call callback if set
+	if d.onNodeFailed != nil {
+		// Release lock for callback to prevent deadlocks
+		d.mu.Unlock()
+		d.onNodeFailed(event)
+		d.mu.Lock()
+	}
+
+	// Notify all subscribers (non-blocking)
+	for _, ch := range d.subscribers {
+		select {
+		case ch <- event:
+		default:
+			// Channel is full, skip to prevent blocking
+		}
+	}
+}
+
+// ResetNodeState resets the failure detection state for a specific node.
+// This can be used when a node recovers and should be monitored fresh.
+func (d *Detector) ResetNodeState(nodeID string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.nodeStates, nodeID)
+}
+
+// GetNodeState returns the current failure detection state for a node.
+// Returns nil if the node is not being tracked.
+func (d *Detector) GetNodeState(nodeID string) *nodeState {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if state, exists := d.nodeStates[nodeID]; exists {
+		// Return a copy to prevent external modification
+		copy := *state
+		return &copy
+	}
+	return nil
+}
+
+// CheckNow triggers an immediate node health check.
+// This is useful for testing or when you want to check immediately after a change.
+func (d *Detector) CheckNow(ctx context.Context) {
+	d.checkNodes(ctx)
+}

--- a/internal/failure/detector_test.go
+++ b/internal/failure/detector_test.go
@@ -1,0 +1,813 @@
+package failure
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/codelaboratoryltd/nexus/internal/store"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// mockNodeStore implements NodeStore for testing.
+type mockNodeStore struct {
+	mu    sync.Mutex
+	nodes []*store.Node
+	err   error
+}
+
+func newMockNodeStore() *mockNodeStore {
+	return &mockNodeStore{
+		nodes: make([]*store.Node, 0),
+	}
+}
+
+func (m *mockNodeStore) ListNodes(ctx context.Context) ([]*store.Node, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return nil, m.err
+	}
+	// Return a copy to prevent test interference
+	result := make([]*store.Node, len(m.nodes))
+	copy(result, m.nodes)
+	return result, nil
+}
+
+func (m *mockNodeStore) SetNodes(nodes []*store.Node) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nodes = nodes
+}
+
+func (m *mockNodeStore) SetError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.err = err
+}
+
+// Helper to create a node with a specific best_before time.
+func createNode(id string, bestBefore time.Time) *store.Node {
+	return &store.Node{
+		ID:         id,
+		BestBefore: bestBefore,
+		Metadata:   map[string]string{"name": "Nexus"},
+	}
+}
+
+func TestNewDetector(t *testing.T) {
+	nodeStore := newMockNodeStore()
+	detector := NewDetector(nodeStore)
+
+	if detector == nil {
+		t.Fatal("NewDetector returned nil")
+	}
+
+	if detector.store != nodeStore {
+		t.Error("Detector store was not set correctly")
+	}
+
+	// Check default config
+	if detector.config.CheckInterval != DefaultCheckInterval {
+		t.Errorf("Default CheckInterval = %v, want %v", detector.config.CheckInterval, DefaultCheckInterval)
+	}
+	if detector.config.FailureTimeout != DefaultFailureTimeout {
+		t.Errorf("Default FailureTimeout = %v, want %v", detector.config.FailureTimeout, DefaultFailureTimeout)
+	}
+}
+
+func TestNewDetectorWithOptions(t *testing.T) {
+	nodeStore := newMockNodeStore()
+	customConfig := Config{
+		CheckInterval:  5 * time.Second,
+		FailureTimeout: 15 * time.Second,
+		GracePeriod:    3 * time.Second,
+	}
+
+	callback := func(event NodeFailedEvent) {
+		// Callback provided to test option setting
+		_ = event
+	}
+
+	registry := prometheus.NewRegistry()
+	metrics := NewMetrics(registry)
+
+	detector := NewDetector(nodeStore,
+		WithConfig(customConfig),
+		WithMetrics(metrics),
+		WithCallback(callback),
+	)
+
+	if detector.config.CheckInterval != customConfig.CheckInterval {
+		t.Errorf("CheckInterval = %v, want %v", detector.config.CheckInterval, customConfig.CheckInterval)
+	}
+	if detector.config.FailureTimeout != customConfig.FailureTimeout {
+		t.Errorf("FailureTimeout = %v, want %v", detector.config.FailureTimeout, customConfig.FailureTimeout)
+	}
+	if detector.metrics != metrics {
+		t.Error("Metrics was not set correctly")
+	}
+	if detector.onNodeFailed == nil {
+		t.Error("Callback was not set")
+	}
+}
+
+func TestDetectorStartStop(t *testing.T) {
+	nodeStore := newMockNodeStore()
+	detector := NewDetector(nodeStore, WithConfig(Config{
+		CheckInterval:  50 * time.Millisecond,
+		FailureTimeout: 100 * time.Millisecond,
+		GracePeriod:    10 * time.Millisecond,
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start the detector
+	if err := detector.Start(ctx); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	if !detector.IsRunning() {
+		t.Error("Detector should be running after Start")
+	}
+
+	// Starting again should be a no-op
+	if err := detector.Start(ctx); err != nil {
+		t.Fatalf("Second Start failed: %v", err)
+	}
+
+	// Stop the detector
+	detector.Stop()
+
+	// Give it time to stop
+	time.Sleep(100 * time.Millisecond)
+
+	if detector.IsRunning() {
+		t.Error("Detector should not be running after Stop")
+	}
+
+	// Stopping again should be a no-op
+	detector.Stop()
+}
+
+func TestDetectorContextCancellation(t *testing.T) {
+	nodeStore := newMockNodeStore()
+	detector := NewDetector(nodeStore, WithConfig(Config{
+		CheckInterval:  50 * time.Millisecond,
+		FailureTimeout: 100 * time.Millisecond,
+		GracePeriod:    10 * time.Millisecond,
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if err := detector.Start(ctx); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	if !detector.IsRunning() {
+		t.Error("Detector should be running")
+	}
+
+	// Cancel context
+	cancel()
+
+	// Give it time to react
+	time.Sleep(100 * time.Millisecond)
+
+	if detector.IsRunning() {
+		t.Error("Detector should stop when context is cancelled")
+	}
+}
+
+func TestDetectorDetectsExpiredNode(t *testing.T) {
+	nodeStore := newMockNodeStore()
+
+	// Create a node that's already expired
+	expiredNode := createNode("node1", time.Now().Add(-1*time.Minute))
+	nodeStore.SetNodes([]*store.Node{expiredNode})
+
+	var failedEvents []NodeFailedEvent
+	var mu sync.Mutex
+
+	callback := func(event NodeFailedEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		failedEvents = append(failedEvents, event)
+	}
+
+	detector := NewDetector(nodeStore,
+		WithConfig(Config{
+			CheckInterval:  10 * time.Millisecond,
+			FailureTimeout: 0, // No additional timeout - fail immediately when expired
+			GracePeriod:    0, // No grace period
+		}),
+		WithCallback(callback),
+	)
+
+	ctx := context.Background()
+
+	// Do a single check
+	detector.CheckNow(ctx)
+
+	mu.Lock()
+	eventCount := len(failedEvents)
+	mu.Unlock()
+
+	if eventCount != 1 {
+		t.Errorf("Expected 1 failure event, got %d", eventCount)
+	}
+
+	mu.Lock()
+	if len(failedEvents) > 0 {
+		event := failedEvents[0]
+		if event.NodeID != "node1" {
+			t.Errorf("Expected NodeID 'node1', got '%s'", event.NodeID)
+		}
+		if event.TimeSinceDue < time.Minute {
+			t.Errorf("Expected TimeSinceDue >= 1 minute, got %v", event.TimeSinceDue)
+		}
+	}
+	mu.Unlock()
+}
+
+func TestDetectorDoesNotEmitDuplicateFailures(t *testing.T) {
+	nodeStore := newMockNodeStore()
+
+	// Create an expired node
+	expiredNode := createNode("node1", time.Now().Add(-1*time.Minute))
+	nodeStore.SetNodes([]*store.Node{expiredNode})
+
+	var failedEvents []NodeFailedEvent
+	var mu sync.Mutex
+
+	callback := func(event NodeFailedEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		failedEvents = append(failedEvents, event)
+	}
+
+	detector := NewDetector(nodeStore,
+		WithConfig(Config{
+			CheckInterval:  10 * time.Millisecond,
+			FailureTimeout: 0,
+			GracePeriod:    0,
+		}),
+		WithCallback(callback),
+	)
+
+	ctx := context.Background()
+
+	// Do multiple checks
+	detector.CheckNow(ctx)
+	detector.CheckNow(ctx)
+	detector.CheckNow(ctx)
+
+	mu.Lock()
+	eventCount := len(failedEvents)
+	mu.Unlock()
+
+	// Should only get one event, not three
+	if eventCount != 1 {
+		t.Errorf("Expected 1 failure event (no duplicates), got %d", eventCount)
+	}
+}
+
+func TestDetectorResetsStateWhenNodeRecovers(t *testing.T) {
+	nodeStore := newMockNodeStore()
+
+	var failedEvents []NodeFailedEvent
+	var mu sync.Mutex
+
+	callback := func(event NodeFailedEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		failedEvents = append(failedEvents, event)
+	}
+
+	detector := NewDetector(nodeStore,
+		WithConfig(Config{
+			CheckInterval:  10 * time.Millisecond,
+			FailureTimeout: 0,
+			GracePeriod:    0,
+		}),
+		WithCallback(callback),
+	)
+
+	ctx := context.Background()
+
+	// Start with expired node
+	expiredNode := createNode("node1", time.Now().Add(-1*time.Minute))
+	nodeStore.SetNodes([]*store.Node{expiredNode})
+	detector.CheckNow(ctx)
+
+	mu.Lock()
+	if len(failedEvents) != 1 {
+		t.Errorf("Expected 1 failure event, got %d", len(failedEvents))
+	}
+	mu.Unlock()
+
+	// Node recovers (best_before is in the future)
+	recoveredNode := createNode("node1", time.Now().Add(1*time.Hour))
+	nodeStore.SetNodes([]*store.Node{recoveredNode})
+	detector.CheckNow(ctx)
+
+	// Node expires again
+	expiredAgain := createNode("node1", time.Now().Add(-1*time.Minute))
+	nodeStore.SetNodes([]*store.Node{expiredAgain})
+	detector.CheckNow(ctx)
+
+	mu.Lock()
+	eventCount := len(failedEvents)
+	mu.Unlock()
+
+	// Should get a second failure event since the node recovered in between
+	if eventCount != 2 {
+		t.Errorf("Expected 2 failure events after recovery and re-expiration, got %d", eventCount)
+	}
+}
+
+func TestDetectorGracePeriod(t *testing.T) {
+	nodeStore := newMockNodeStore()
+
+	// Create a node that just expired
+	expiredNode := createNode("node1", time.Now().Add(-10*time.Millisecond))
+	nodeStore.SetNodes([]*store.Node{expiredNode})
+
+	var failedEvents []NodeFailedEvent
+	var mu sync.Mutex
+
+	callback := func(event NodeFailedEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		failedEvents = append(failedEvents, event)
+	}
+
+	detector := NewDetector(nodeStore,
+		WithConfig(Config{
+			CheckInterval:  10 * time.Millisecond,
+			FailureTimeout: 1 * time.Hour, // Long timeout - we're testing grace period
+			GracePeriod:    100 * time.Millisecond,
+		}),
+		WithCallback(callback),
+	)
+
+	ctx := context.Background()
+
+	// First check - should not fail yet (grace period not exceeded)
+	detector.CheckNow(ctx)
+
+	mu.Lock()
+	eventCount := len(failedEvents)
+	mu.Unlock()
+
+	if eventCount != 0 {
+		t.Errorf("Expected 0 failure events before grace period, got %d", eventCount)
+	}
+
+	// Wait for grace period to pass
+	time.Sleep(150 * time.Millisecond)
+
+	// Second check - should now detect failure
+	detector.CheckNow(ctx)
+
+	mu.Lock()
+	eventCount = len(failedEvents)
+	mu.Unlock()
+
+	if eventCount != 1 {
+		t.Errorf("Expected 1 failure event after grace period, got %d", eventCount)
+	}
+}
+
+func TestDetectorSubscription(t *testing.T) {
+	nodeStore := newMockNodeStore()
+
+	// Create an expired node
+	expiredNode := createNode("node1", time.Now().Add(-1*time.Minute))
+	nodeStore.SetNodes([]*store.Node{expiredNode})
+
+	detector := NewDetector(nodeStore,
+		WithConfig(Config{
+			CheckInterval:  10 * time.Millisecond,
+			FailureTimeout: 0,
+			GracePeriod:    0,
+		}),
+	)
+
+	// Create subscriber channels
+	ch1 := make(chan NodeFailedEvent, 10)
+	ch2 := make(chan NodeFailedEvent, 10)
+
+	detector.Subscribe(ch1)
+	detector.Subscribe(ch2)
+
+	ctx := context.Background()
+	detector.CheckNow(ctx)
+
+	// Both channels should receive the event
+	select {
+	case event := <-ch1:
+		if event.NodeID != "node1" {
+			t.Errorf("ch1: Expected NodeID 'node1', got '%s'", event.NodeID)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("ch1: Did not receive event")
+	}
+
+	select {
+	case event := <-ch2:
+		if event.NodeID != "node1" {
+			t.Errorf("ch2: Expected NodeID 'node1', got '%s'", event.NodeID)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("ch2: Did not receive event")
+	}
+
+	// Unsubscribe ch1
+	detector.Unsubscribe(ch1)
+
+	// Reset node state and make it fail again
+	detector.ResetNodeState("node1")
+	detector.CheckNow(ctx)
+
+	// Only ch2 should receive the second event
+	select {
+	case <-ch1:
+		t.Error("ch1 should not receive event after unsubscribe")
+	case <-time.After(50 * time.Millisecond):
+		// Expected - ch1 is unsubscribed
+	}
+
+	select {
+	case event := <-ch2:
+		if event.NodeID != "node1" {
+			t.Errorf("ch2: Expected NodeID 'node1', got '%s'", event.NodeID)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("ch2: Did not receive second event")
+	}
+}
+
+func TestDetectorMetrics(t *testing.T) {
+	nodeStore := newMockNodeStore()
+
+	registry := prometheus.NewRegistry()
+	metrics := NewMetrics(registry)
+
+	// Create nodes - one healthy, one expired
+	healthyNode := createNode("healthy", time.Now().Add(1*time.Hour))
+	expiredNode := createNode("expired", time.Now().Add(-1*time.Minute))
+	nodeStore.SetNodes([]*store.Node{healthyNode, expiredNode})
+
+	detector := NewDetector(nodeStore,
+		WithConfig(Config{
+			CheckInterval:  10 * time.Millisecond,
+			FailureTimeout: 0,
+			GracePeriod:    0,
+		}),
+		WithMetrics(metrics),
+	)
+
+	ctx := context.Background()
+	detector.CheckNow(ctx)
+
+	// Gather metrics
+	mfs, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	// Check metrics values
+	metricsMap := make(map[string]float64)
+	for _, mf := range mfs {
+		for _, m := range mf.GetMetric() {
+			switch *mf.Name {
+			case "nexus_failure_detector_nodes_monitored":
+				metricsMap["nodes_monitored"] = m.GetGauge().GetValue()
+			case "nexus_failure_detector_nodes_healthy":
+				metricsMap["nodes_healthy"] = m.GetGauge().GetValue()
+			case "nexus_failure_detector_nodes_expired":
+				metricsMap["nodes_expired"] = m.GetGauge().GetValue()
+			case "nexus_failure_detector_nodes_failed_total":
+				metricsMap["nodes_failed_total"] = m.GetCounter().GetValue()
+			}
+		}
+	}
+
+	if metricsMap["nodes_monitored"] != 2 {
+		t.Errorf("nodes_monitored = %v, want 2", metricsMap["nodes_monitored"])
+	}
+	if metricsMap["nodes_healthy"] != 1 {
+		t.Errorf("nodes_healthy = %v, want 1", metricsMap["nodes_healthy"])
+	}
+	if metricsMap["nodes_expired"] != 1 {
+		t.Errorf("nodes_expired = %v, want 1", metricsMap["nodes_expired"])
+	}
+	if metricsMap["nodes_failed_total"] != 1 {
+		t.Errorf("nodes_failed_total = %v, want 1", metricsMap["nodes_failed_total"])
+	}
+}
+
+func TestDetectorHandlesStoreError(t *testing.T) {
+	nodeStore := newMockNodeStore()
+	nodeStore.SetError(store.ErrPoolNotFound) // Any error
+
+	detector := NewDetector(nodeStore,
+		WithConfig(Config{
+			CheckInterval:  10 * time.Millisecond,
+			FailureTimeout: 0,
+			GracePeriod:    0,
+		}),
+	)
+
+	ctx := context.Background()
+
+	// Should not panic when store returns error
+	detector.CheckNow(ctx)
+}
+
+func TestDetectorCleansUpRemovedNodes(t *testing.T) {
+	nodeStore := newMockNodeStore()
+
+	// Start with two nodes
+	node1 := createNode("node1", time.Now().Add(1*time.Hour))
+	node2 := createNode("node2", time.Now().Add(1*time.Hour))
+	nodeStore.SetNodes([]*store.Node{node1, node2})
+
+	detector := NewDetector(nodeStore,
+		WithConfig(Config{
+			CheckInterval:  10 * time.Millisecond,
+			FailureTimeout: 0,
+			GracePeriod:    0,
+		}),
+	)
+
+	ctx := context.Background()
+	detector.CheckNow(ctx)
+
+	// Check that both nodes are tracked
+	if state := detector.GetNodeState("node1"); state == nil {
+		t.Error("node1 should be tracked")
+	}
+	if state := detector.GetNodeState("node2"); state == nil {
+		t.Error("node2 should be tracked")
+	}
+
+	// Remove node2
+	nodeStore.SetNodes([]*store.Node{node1})
+	detector.CheckNow(ctx)
+
+	// node2 should be cleaned up
+	if state := detector.GetNodeState("node2"); state != nil {
+		t.Error("node2 should be cleaned up after removal")
+	}
+	if state := detector.GetNodeState("node1"); state == nil {
+		t.Error("node1 should still be tracked")
+	}
+}
+
+func TestDetectorResetNodeState(t *testing.T) {
+	nodeStore := newMockNodeStore()
+
+	// Create an expired node
+	expiredNode := createNode("node1", time.Now().Add(-1*time.Minute))
+	nodeStore.SetNodes([]*store.Node{expiredNode})
+
+	var failedEvents []NodeFailedEvent
+	var mu sync.Mutex
+
+	callback := func(event NodeFailedEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		failedEvents = append(failedEvents, event)
+	}
+
+	detector := NewDetector(nodeStore,
+		WithConfig(Config{
+			CheckInterval:  10 * time.Millisecond,
+			FailureTimeout: 0,
+			GracePeriod:    0,
+		}),
+		WithCallback(callback),
+	)
+
+	ctx := context.Background()
+
+	// First check
+	detector.CheckNow(ctx)
+
+	mu.Lock()
+	if len(failedEvents) != 1 {
+		t.Errorf("Expected 1 failure event, got %d", len(failedEvents))
+	}
+	mu.Unlock()
+
+	// Reset the state
+	detector.ResetNodeState("node1")
+
+	// Check again - should detect failure again
+	detector.CheckNow(ctx)
+
+	mu.Lock()
+	if len(failedEvents) != 2 {
+		t.Errorf("Expected 2 failure events after reset, got %d", len(failedEvents))
+	}
+	mu.Unlock()
+}
+
+func TestDetectorMultipleNodes(t *testing.T) {
+	nodeStore := newMockNodeStore()
+
+	// Create mix of healthy and expired nodes
+	healthy1 := createNode("healthy1", time.Now().Add(1*time.Hour))
+	healthy2 := createNode("healthy2", time.Now().Add(2*time.Hour))
+	expired1 := createNode("expired1", time.Now().Add(-1*time.Minute))
+	expired2 := createNode("expired2", time.Now().Add(-2*time.Minute))
+
+	nodeStore.SetNodes([]*store.Node{healthy1, healthy2, expired1, expired2})
+
+	var failedEvents []NodeFailedEvent
+	var mu sync.Mutex
+
+	callback := func(event NodeFailedEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		failedEvents = append(failedEvents, event)
+	}
+
+	detector := NewDetector(nodeStore,
+		WithConfig(Config{
+			CheckInterval:  10 * time.Millisecond,
+			FailureTimeout: 0,
+			GracePeriod:    0,
+		}),
+		WithCallback(callback),
+	)
+
+	ctx := context.Background()
+	detector.CheckNow(ctx)
+
+	mu.Lock()
+	eventCount := len(failedEvents)
+	mu.Unlock()
+
+	// Should detect both expired nodes
+	if eventCount != 2 {
+		t.Errorf("Expected 2 failure events, got %d", eventCount)
+	}
+
+	// Verify the failed nodes
+	mu.Lock()
+	failedNodeIDs := make(map[string]bool)
+	for _, e := range failedEvents {
+		failedNodeIDs[e.NodeID] = true
+	}
+	mu.Unlock()
+
+	if !failedNodeIDs["expired1"] {
+		t.Error("expired1 should be in failed events")
+	}
+	if !failedNodeIDs["expired2"] {
+		t.Error("expired2 should be in failed events")
+	}
+	if failedNodeIDs["healthy1"] {
+		t.Error("healthy1 should not be in failed events")
+	}
+	if failedNodeIDs["healthy2"] {
+		t.Error("healthy2 should not be in failed events")
+	}
+}
+
+func TestDetectorRunningIntegration(t *testing.T) {
+	nodeStore := newMockNodeStore()
+
+	// Start with healthy node
+	healthyNode := createNode("node1", time.Now().Add(200*time.Millisecond))
+	nodeStore.SetNodes([]*store.Node{healthyNode})
+
+	var failedEvents []NodeFailedEvent
+	var mu sync.Mutex
+
+	callback := func(event NodeFailedEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		failedEvents = append(failedEvents, event)
+	}
+
+	detector := NewDetector(nodeStore,
+		WithConfig(Config{
+			CheckInterval:  50 * time.Millisecond,
+			FailureTimeout: 0,
+			GracePeriod:    0,
+		}),
+		WithCallback(callback),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := detector.Start(ctx); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	// Wait for node to expire
+	time.Sleep(350 * time.Millisecond)
+
+	mu.Lock()
+	eventCount := len(failedEvents)
+	mu.Unlock()
+
+	if eventCount == 0 {
+		t.Error("Expected failure event after node expired")
+	}
+
+	detector.Stop()
+}
+
+func TestDetectorSubscriberFullChannel(t *testing.T) {
+	nodeStore := newMockNodeStore()
+
+	// Create an expired node
+	expiredNode := createNode("node1", time.Now().Add(-1*time.Minute))
+	nodeStore.SetNodes([]*store.Node{expiredNode})
+
+	detector := NewDetector(nodeStore,
+		WithConfig(Config{
+			CheckInterval:  10 * time.Millisecond,
+			FailureTimeout: 0,
+			GracePeriod:    0,
+		}),
+	)
+
+	// Create a channel with no buffer
+	ch := make(chan NodeFailedEvent)
+	detector.Subscribe(ch)
+
+	ctx := context.Background()
+
+	// This should not block even though channel is full
+	done := make(chan bool)
+	go func() {
+		detector.CheckNow(ctx)
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Good - didn't block
+	case <-time.After(1 * time.Second):
+		t.Error("CheckNow blocked on full subscriber channel")
+	}
+}
+
+func TestNewMetrics(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := NewMetrics(registry)
+
+	if metrics == nil {
+		t.Fatal("NewMetrics returned nil")
+	}
+
+	if metrics.NodesFailedTotal == nil {
+		t.Error("NodesFailedTotal is nil")
+	}
+	if metrics.DetectionLatency == nil {
+		t.Error("DetectionLatency is nil")
+	}
+	if metrics.NodesMonitored == nil {
+		t.Error("NodesMonitored is nil")
+	}
+	if metrics.NodesHealthy == nil {
+		t.Error("NodesHealthy is nil")
+	}
+	if metrics.NodesExpired == nil {
+		t.Error("NodesExpired is nil")
+	}
+	if metrics.CheckDuration == nil {
+		t.Error("CheckDuration is nil")
+	}
+}
+
+func TestNewMetricsNilRegistry(t *testing.T) {
+	// Should work with nil registry (just doesn't register)
+	metrics := NewMetrics(nil)
+	if metrics == nil {
+		t.Fatal("NewMetrics with nil registry returned nil")
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.CheckInterval != DefaultCheckInterval {
+		t.Errorf("CheckInterval = %v, want %v", cfg.CheckInterval, DefaultCheckInterval)
+	}
+	if cfg.FailureTimeout != DefaultFailureTimeout {
+		t.Errorf("FailureTimeout = %v, want %v", cfg.FailureTimeout, DefaultFailureTimeout)
+	}
+	if cfg.GracePeriod != DefaultGracePeriod {
+		t.Errorf("GracePeriod = %v, want %v", cfg.GracePeriod, DefaultGracePeriod)
+	}
+}


### PR DESCRIPTION
## Summary

Implements automatic detection of failed Nexus nodes to enable BNG high availability and shard reassignment.

- Add `Detector` struct that monitors node health via `best_before` timestamps
- Configurable check interval, failure timeout, and grace period
- Callback and channel-based event notification
- Prometheus metrics for monitoring

## Key Features

- **Grace period**: Prevents flapping from transient network issues (default 5s)
- **Configurable timeouts**: Check interval (10s), failure timeout (30s)
- **Dual notification**: Both callback function and channel subscription patterns
- **Lifecycle management**: `Start(ctx)`, `Stop()`, `IsRunning()`, `CheckNow(ctx)`

## Prometheus Metrics

| Metric | Type | Description |
|--------|------|-------------|
| `nexus_failure_detector_nodes_failed_total` | Counter | Total failures detected |
| `nexus_failure_detector_detection_latency_seconds` | Histogram | Time from best_before to detection |
| `nexus_failure_detector_nodes_monitored` | Gauge | Nodes being monitored |
| `nexus_failure_detector_nodes_healthy` | Gauge | Healthy nodes |
| `nexus_failure_detector_nodes_expired` | Gauge | Expired but not yet failed |

## Test Plan

- [x] 19 unit tests covering all scenarios
- [x] All tests pass
- [ ] Integration with shard reassignment (#7)

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/code)