### PR TITLE
feat(api): Site assignment and auto-pairing for HA devices

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -74,7 +74,10 @@ func (s *Server) RegisterRoutes(r *mux.Router) {
 	if s.deviceStore != nil {
 		api.HandleFunc("/bootstrap", s.bootstrap).Methods("POST")
 		api.HandleFunc("/devices", s.listDevices).Methods("GET")
+		api.HandleFunc("/devices/import", s.importDevices).Methods("POST")
 		api.HandleFunc("/devices/{node_id}", s.getDevice).Methods("GET")
+		api.HandleFunc("/devices/{node_id}", s.assignDevice).Methods("PUT")
+		api.HandleFunc("/devices/{node_id}", s.deleteDevice).Methods("DELETE")
 	}
 }
 

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -89,6 +89,10 @@ var (
 	// Formats: GPON123456, ABCD12345678, etc.
 	serialNumberPattern = regexp.MustCompile(`^[A-Z0-9]{4,32}$`)
 
+	// siteIDPattern allows alphanumeric characters, hyphens, underscores
+	// Formats: london-1, site_001, datacenter-east-1, etc.
+	siteIDPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}[a-zA-Z0-9]$|^[a-zA-Z0-9]$`)
+
 	// macAddressPattern matches MAC addresses in various formats
 	// Supports: 00:11:22:33:44:55, 00-11-22-33-44-55, 001122334455
 	macAddressPattern = regexp.MustCompile(`^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$|^([0-9A-Fa-f]{12})$`)
@@ -268,6 +272,27 @@ func ValidateSerialNumber(serial string) error {
 
 	if err := checkDangerousInput(serial); err != nil {
 		return NewValidationError("serial_number", serial, "serial number contains potentially dangerous characters", err)
+	}
+
+	return nil
+}
+
+// ValidateSiteID validates a site identifier
+func ValidateSiteID(siteID string) error {
+	if siteID == "" {
+		return NewValidationError("site_id", siteID, "site ID is required", ErrEmptyValue)
+	}
+
+	if len(siteID) > 64 {
+		return NewValidationError("site_id", siteID, "site ID exceeds maximum length of 64", ErrValueTooLong)
+	}
+
+	if !siteIDPattern.MatchString(siteID) {
+		return NewValidationError("site_id", siteID, "site ID must contain only alphanumeric characters, hyphens, and underscores", ErrInvalidFormat)
+	}
+
+	if err := checkDangerousInput(siteID); err != nil {
+		return NewValidationError("site_id", siteID, "site ID contains potentially dangerous characters", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Extends the Bootstrap API to support Tinkerbell-style device provisioning with automatic HA pairing.

**Depends on:** PR #13 (Bootstrap API)

## New Endpoints

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/api/v1/devices/{node_id}` | PUT | Assign device to a site |
| `/api/v1/devices/import` | POST | Bulk CSV import |
| `/api/v1/devices/{node_id}` | DELETE | Remove device (unpairs partner) |

## Auto-Pairing Logic

- First device at a site → `role: "active"`
- Second device at same site → `role: "standby"`, auto-paired with first
- Third device → error (site capacity exceeded)

## Test Plan

- [x] 17 new tests covering all scenarios
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)